### PR TITLE
Read file once instead of once per worker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module sphere2cubeGo
+
+go 1.20

--- a/main.go
+++ b/main.go
@@ -52,9 +52,25 @@ func main() {
 	done := make(chan worker.TileResult)
 	timeStart := time.Now()
 	cacheResult := cache.CacheAnglesHandler(tileSize)
+
+	log.Printf("Read file %v --> started", originalImagePath)
+
+	reader, err := os.Open(originalImagePath)
+	if err != nil {
+		panic(err)
+	}
+	defer reader.Close()
+
+	log.Printf("Read file %v --> finished", originalImagePath)
+
+	originalPixels, err := worker.GetPixels(reader)
+	if err != nil {
+		panic(err)
+	}
+
 	for _, tileName := range tileNames {
 		tile := worker.Tile{TileName: tileName, TileSize: tileSize}
-		go worker.Worker(tile, cacheResult, originalImagePath, done)
+		go worker.Worker(originalPixels, tile, cacheResult, originalImagePath, done)
 	}
 
 	for range tileNames {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1,14 +1,14 @@
 package worker
 
 import (
-	"sphere2cubeGo/cache"
-	"log"
 	"image"
-	"os"
-	"image/jpeg"
 	"image/color"
+	"image/jpeg"
 	"io"
+	"log"
 	"math"
+	"os"
+	"sphere2cubeGo/cache"
 )
 
 const (
@@ -52,7 +52,7 @@ func rgbaToPixel(r uint32, g uint32, b uint32, a uint32) Pixel {
 }
 
 // Get the bi-dimensional pixel array
-func getPixels(file io.Reader) ([][]Pixel, error) {
+func GetPixels(file io.Reader) ([][]Pixel, error) {
 	img, err := jpeg.Decode(file)
 
 	if err != nil {
@@ -143,22 +143,9 @@ func processCords(tileX int, tileY int, originalImage [][]Pixel, tile Tile, math
 	return originalImage[spY][spX]
 }
 
-func Worker(tile Tile, mathCache cache.CacheAngles, originalImagePath string, done chan TileResult) {
+func Worker(originalPixels [][]Pixel, tile Tile, mathCache cache.CacheAngles, originalImagePath string, done chan TileResult) {
 	log.Printf("Process for tile %v --> started", tile.TileName)
 	tileImage := image.NewRGBA(image.Rect(0, 0, tile.TileSize, tile.TileSize))
-	reader, err := os.Open(originalImagePath)
-
-	if err != nil {
-		panic(err)
-	}
-
-	defer reader.Close()
-
-	originalPixels, err := getPixels(reader)
-
-	if err != nil {
-		panic(err)
-	}
 
 	sphereHeight, sphereWidth := len(originalPixels), len(originalPixels[0])
 


### PR DESCRIPTION
### Related issue

#1 

### Problem

As mentioned in the issue, each worker is opening the panorama file independently, this greatly increases the memory and cpu usage without benefits.

### Fix
- Implemented @uglyer 's solution to the code, extracting the file reading to the main file, and passing the pixel matrix data to each worker.

### Testing
Locally
- Builds successfully
- Tested with sample file `panorama.jpg` and worked without problems.

### Other changes
- Added missing `go.mod` file, to solve dependencies on modern Go servers
- Automatic formatting done by Gofmt